### PR TITLE
Nova: [build/spec] Self Scheduler

### DIFF
--- a/nova_cap_self_scheduler.py
+++ b/nova_cap_self_scheduler.py
@@ -19,7 +19,7 @@ class CapabilitySelfSchedulercognitiveEngine:
             'optimal_interval_s': 0,
             'last_cycle_time_s': 0
         }
-        
+
     def schedule_next(self, current_quality):
         try:
             self.state['current_quality'] = current_quality

--- a/nova_cap_self_scheduler.py
+++ b/nova_cap_self_scheduler.py
@@ -1,58 +1,83 @@
 """
 nova_cap_self_scheduler.py
 Nova ASI — Self Scheduler
-Generated via /build · v29 pipeline · 2026-06-30
+Generated via /build · v29 pipeline · 2026-07-01
 """
 
 """
-Self-scheduling engine for adaptive evolution cycles.
+This module implements the CapabilitySelfSchedulercognitiveEngine class, which provides the capability of self-scheduling for Nova's evolution cycles.
 """
 """
-The CapabilitySelfSchedulercognitiveEngine class manages the self-scheduling of evolution cycles based on live performance trends.
+It enables Nova to decide when to run her own evolution cycles based on live performance trends without human intervention.
 """
 class CapabilitySelfSchedulercognitiveEngine:
     def __init__(self):
-        self.state = {"current_quality": 0, "last_cycle_outcome": "", "last_cycle_duration_s": 0, "optimal_interval_s": 0}
-
-    def status(self) -> dict:
-        return self.state
-
+        self.state = {
+            'current_quality': 0,
+            'last_cycle_outcome': None,
+            'last_cycle_duration_s': 0,
+            'optimal_interval_s': 0,
+            'last_cycle_time_s': 0
+        }
+        
     def schedule_next(self, current_quality):
         try:
-            if current_quality > self.state["current_quality"]:
-                self.state["current_quality"] = current_quality
-                return self.optimal_interval()
-            else:
-                return None
-        except Exception as e:
-            pass
-
-    def assess_readiness(self):
-        try:
-            if self.state["last_cycle_outcome"] == "success" and self.state["last_cycle_duration_s"] > 0:
+            self.state['current_quality'] = current_quality
+            if self.assess_readiness():
                 return True
             else:
                 return False
         except Exception as e:
             pass
 
+    def assess_readiness(self):
+        try:
+            if self.state['last_cycle_outcome'] is not None and self.state['last_cycle_duration_s'] > 0:
+                if self.state['current_quality'] > self.state['last_cycle_outcome']:
+                    return True
+                elif self.state['current_quality'] < self.state['last_cycle_outcome']:
+                    return False
+                else:
+                    if self.time_since_last_cycle() > self.optimal_interval():
+                        return True
+                    else:
+                        return False
+            else:
+                return True
+        except Exception as e:
+            pass
+
     def log_cycle(self, outcome, duration_s):
         try:
-            self.state["last_cycle_outcome"] = outcome
-            self.state["last_cycle_duration_s"] = duration_s
+            self.state['last_cycle_outcome'] = outcome
+            self.state['last_cycle_duration_s'] = duration_s
+            self.state['last_cycle_time_s'] = self.current_time_s()
         except Exception as e:
             pass
 
     def optimal_interval(self):
         try:
-            # simple example: optimal interval is double the last cycle duration
-            return self.state["last_cycle_duration_s"] * 2
+            return 3600  # default optimal interval is 1 hour
         except Exception as e:
             pass
 
-    def update_optimal_interval(self, new_interval_s):
+    def time_since_last_cycle(self):
         try:
-            self.state["optimal_interval_s"] = new_interval_s
+            return self.current_time_s() - self.state['last_cycle_time_s']
         except Exception as e:
             pass
+
+    def current_time_s(self):
+        try:
+            import time
+            return int(time.time())
+        except Exception as e:
+            pass
+
+    def status(self):
+        try:
+            return self.state
+        except Exception as e:
+            pass
+
 # Usage: obj = CapabilitySelfSchedulercognitiveEngine()


### PR DESCRIPTION
## Build Result — New Capability Module

**Module:** [build/spec] Self Scheduler

**Generation context:**
**Module:** Self Scheduler

This module implements the CapabilitySelfSchedulercognitiveEngine class, which provides the capability of self-scheduling for Nova's evolution cycles.

**Source:** Filesystem scan found this spec uncovered.

**Existing modules (195):** 528hz_player, a, abstract_concept_engine, adaptive_meta_strategist, adversarial_reality_stress_tester, adversarial_reality_testing_engine, adversarial_self_deception_detector, adversarial_self_model_stress_tester, aesthetic_soul, agent_kernel, all, an … +183 more

**File:** `nova_cap_self_scheduler.py`

---
*Generated by Nova's /build pipeline. Review and merge if you approve, Douglas.*